### PR TITLE
code with synt highlight updated with md code

### DIFF
--- a/content/en/paragraph.md
+++ b/content/en/paragraph.md
@@ -43,10 +43,27 @@ Text in this position
           other text
 ```
 
-## Code With Syntax Highlighing
+## Code With Syntax Highlighting
 
-Use e.g. (```XML) to displayed XML.
+To add syntax highlighting, specify a code type next to the backticks <code>(```)</code> before the fenced code block.
 
+Displayed e.g. XML code block:
+```XML
+<?xml version="1.0" encoding="UTF-8"?>
+<LWM2M xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" 
+       xsi:noNamespaceSchemaLocation=
+           "http://openmobilealliance.org/tech/profiles/LWM2M.xsd" >
+                <Object ObjectType="MODefinition">
+                                <Name>MyDevice</Name>
+                                <ObjectID>44</ObjectID>
+                                <LWM2MVersion>1.1</LWM2MVersion>
+               </Object>
+</LWM2M>
+
+```
+This is how XML code block is written in markdown:
+
+````
 ```XML
 <?xml version="1.0" encoding="UTF-8"?>
 <LWM2M xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" 
@@ -59,11 +76,10 @@ Use e.g. (```XML) to displayed XML.
                </Object>
 </LWM2M>
 ```
-
+````
 
 <alert>
-For the list of keywords see https://highlightjs.org/ e.g. Java, JSON, XML
-The text language should be indicated in order to enable this syntax highlighting functionality.
+For the list of keywords see https://highlightjs.org/ e.g. Java, JSON, XML. The text language should be indicated in order to enable this syntax highlighting functionality.
 </alert>
 
 <alert type='warning'>


### PR DESCRIPTION
Code with Syntax Highlighting Section has been updated with `md` code. Some rewording was made, please review at  6ce68e18bfa43c79b26a0660ca4310323a6b46ea.
This is done to resolve issue #3 but is here to be applied to the new document structure.