### PR TITLE
Blockquote redundtant

### DIFF
--- a/content/en/paragraph.md
+++ b/content/en/paragraph.md
@@ -13,12 +13,12 @@ category: MD2HTML App
 
 This is how a `blockquote` is displayed:
 
-> blockquote
+> This is a blockquote text.
 
 This is how a `blockquote` is written in markdown:
 
 ```md
-> blockquote
+> This is a blockquote text.
 ```
 ## Code
 This is how `code` is displayed:

--- a/content/en/paragraph.md
+++ b/content/en/paragraph.md
@@ -90,16 +90,6 @@ Paragraph one.
 Paragraph two. 
 Another line immediately afterwards will be displayed starting on the same line as paragraph two.
 
-## Block Quote
-
-* To indent and mark text use:
-
-```md
-> OMA LwM2M
-```
-
-> OMA LwM2M
-
 ## Non-breaking Space
 
 * To insert a non-breaking space use:


### PR DESCRIPTION
The Blockquote section was deleted as redundant. The other one is the second subsection in the Paragraph section. Please review at 70c9b149bb81b96d8f46475dcf99625663d6cd03.
