### PR TITLE
Preformatted text

### DIFF
--- a/content/en/paragraph.md
+++ b/content/en/paragraph.md
@@ -38,6 +38,7 @@ This is how `code` is written in markdown:
 * Use (```) with caution. Line breaks are not automatically inserted so in PDF text may not be fully displayed.
 
 This is how `preformatted text` is displayed:
+
 ```
 Text in this position
     other text dented to the right
@@ -45,12 +46,16 @@ Text in this position
 
           other text
 ```
+
 Preformatted text written in markdown:
+
 ````
-```
+```md
 Text in this position
     other text dented to the right
   other text dented to the left
+```
+````
 
 ## Code With Syntax Highlighting
 
@@ -58,6 +63,7 @@ Text in this position
 To add syntax highlighting, specify a code type next to the backticks <code>(```)</code> before the fenced code block.
 
 Displayed e.g. XML code block:
+
 ```XML
 <?xml version="1.0" encoding="UTF-8"?>
 <LWM2M xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" 
@@ -69,7 +75,6 @@ Displayed e.g. XML code block:
                                 <LWM2MVersion>1.1</LWM2MVersion>
                </Object>
 </LWM2M>
-
 ```
 This is how XML code block is written in markdown:
 

--- a/content/en/paragraph.md
+++ b/content/en/paragraph.md
@@ -32,20 +32,29 @@ This is how `code` is written in markdown:
 `code`
 ```
 
-## Preformated Text
+## Preformatted Text
 
-* Use (```) to indicate the beginning and end of preformatted text block
-    * Add the markup name on the first, e.g. (```xml)
-* Use (```) with caution. Line breaks are not automatically inserted so in PDF text may not be fully displayed
+* Use (```) to indicate the beginning and end of preformatted text block.
+* Use (```) with caution. Line breaks are not automatically inserted so in PDF text may not be fully displayed.
 
-```md
+This is how `preformatted text` is displayed:
+```
 Text in this position
     other text dented to the right
   other text dented to the left
 
           other text
 ```
+Preformatted text written in markdown:
+````
+```
+Text in this position
+    other text dented to the right
+  other text dented to the left
 
+          other text
+```
+````
 ## Code With Syntax Highlighing
 
 Use e.g. (```XML) to displayed XML.


### PR DESCRIPTION
Line `Add the markup name on the first, e.g. (```xml)` was deleted, because the section Code with Syntax Highlighting contains the same example.
Also `markdown` code was added afterward. (0a546446bef25b0b200d53f17610f83040830a3d)
