### PR TITLE
Add code sandbox to nuxtjs

### DIFF
--- a/content/en/nuxt-code-sandbox.md
+++ b/content/en/nuxt-code-sandbox.md
@@ -2,8 +2,8 @@
 title: Code Box
 menuTitle: Code Sandbox
 description: 'Live example of Nuxt Content docs theme on CodeSandbox.'
-position: 450
-category: 
+position: 40
+category: Introduction
 csb_link: https://codesandbox.io/embed/nuxt-content-docs-theme-playground-inwxb?hidenavigation=1&theme=dark
 fullscreen: true
 ---

--- a/content/en/nuxtjs.md
+++ b/content/en/nuxtjs.md
@@ -442,6 +442,14 @@ This is how a `code-block` is written in markdown:
   </code-block>
 </code-group>
 ```
+### Code Sandbox
+This is how a `code-sandbox` is displayed:
+<code-sandbox src="https://codesandbox.io/embed/nuxt-content-docs-theme-playground-inwxb?hidenavigation=1&theme=dar"></code-sandbox>
+
+This is how a `code-sandbox` is written in markdown:
+```md
+<code-sandbox src="https://codesandbox.io/embed/nuxt-content-docs-theme-playground-inwxb?hidenavigation=1&theme=dar"></code-sandbox>
+```
 
 ### Videos
 


### PR DESCRIPTION
The Sandbox content has been moved into the `nuxtjs.md` file as a new section, `Code Sandbox`.
Please check if the placeholder sounds right to you.
I wasn't sure if the Code Sandbox category should be deleted?
